### PR TITLE
feat: add dotfiles structure with install script and copilot skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 # dotfiles
 
 My dotfiles in order to make me feel at `$home` in no time.
+
+## Structure
+
+```
+dotfiles/
+├── copilot/
+│   ├── agents/          # Custom GitHub Copilot agents (.agent.md)
+│   └── skills/          # Agent skills (folders with SKILL.md)
+├── install.ps1          # Symlink setup script
+└── README.md
+```
+
+## Setup
+
+Clone the repo and run the install script to create symlinks:
+
+```powershell
+git clone https://github.com/p2well/dotfiles.git ~/dev/dotfiles
+cd ~/dev/dotfiles
+.\install.ps1
+```
+
+This creates the following links:
+
+| Source | Target |
+|--------|--------|
+| `copilot/agents/` | `~/.copilot/agents/` |
+| `copilot/skills/` | `~/.copilot/skills/` |
+
+Restart VS Code after running the script.

--- a/copilot/skills/commit-message/SKILL.md
+++ b/copilot/skills/commit-message/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: commit-message
+description: Generate conventional commit messages - use when creating commits, writing commit messages, or asking for git commit help
+---
+
+# Commit Message Skill
+
+Generate commit messages following the Conventional Commits specification.
+
+## Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+## Types
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting (no code change) |
+| `refactor` | Code change that neither fixes nor adds |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance tasks |
+
+## Rules
+
+1. Subject line maximum 72 characters
+2. Use imperative mood ("add" not "added" or "adds")
+3. No period at the end of subject line
+4. Separate subject from body with blank line
+5. Body explains **what** and **why**, not how
+
+## Examples
+
+Simple:
+```
+fix(auth): prevent redirect loop on expired sessions
+```
+
+With body:
+```
+feat(api): add rate limiting to public endpoints
+
+- Limits requests to 100/minute per IP
+- Returns 429 status with retry-after header
+- Configurable via RATE_LIMIT_MAX env variable
+
+Closes #234
+```

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Sets up symlinks from this dotfiles repo to the expected locations on the system.
+
+.DESCRIPTION
+    Creates directory junctions so that tools like VS Code / GitHub Copilot
+    pick up agents and skills from this version-controlled repo.
+
+    Run this script once after cloning the repo on a new machine.
+
+.EXAMPLE
+    .\install.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$dotfilesRoot = $PSScriptRoot
+
+$links = @(
+    @{ Target = "$dotfilesRoot\copilot\agents"; Link = "$HOME\.copilot\agents" }
+    @{ Target = "$dotfilesRoot\copilot\skills"; Link = "$HOME\.copilot\skills" }
+)
+
+foreach ($entry in $links) {
+    $link   = $entry.Link
+    $target = $entry.Target
+
+    if (Test-Path $link) {
+        $item = Get-Item $link -Force
+        if ($item.LinkType -eq "Junction" -or $item.LinkType -eq "SymbolicLink") {
+            Write-Host "  Removing existing link: $link"
+            $item.Delete()
+        } else {
+            Write-Warning "  '$link' exists and is not a symlink. Skipping — back it up and remove it manually."
+            continue
+        }
+    }
+
+    $parentDir = Split-Path $link -Parent
+    if (!(Test-Path $parentDir)) {
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+    }
+
+    New-Item -ItemType Junction -Path $link -Target $target | Out-Null
+    Write-Host "  Linked: $link -> $target"
+}
+
+Write-Host "`nDone. Restart VS Code to pick up changes."


### PR DESCRIPTION
This pull request adds a new setup process for the repository, making it easier to configure and use custom Copilot agents and skills. It introduces a PowerShell installation script, documents the repository structure and installation steps, and adds a new Copilot skill for generating conventional commit messages.

**Repository setup and documentation:**

* Added a new `install.ps1` PowerShell script to automatically create symlinks (directory junctions) from the repo's `copilot/agents` and `copilot/skills` folders to the user's `~/.copilot` directory, simplifying setup on new machines.
* Updated `README.md` to include a description of the repository structure, detailed setup instructions, and a table of symlink mappings created by the install script.

**Copilot skills:**

* Added a new `commit-message` skill in `copilot/skills/commit-message/SKILL.md` that describes how to generate commit messages following the Conventional Commits specification, including usage rules, types, and examples.